### PR TITLE
Микросетки на флексах для всех страниц

### DIFF
--- a/catalog.html
+++ b/catalog.html
@@ -185,11 +185,11 @@
 
                 <div class="sort-button-wrapper">
                   <a class="select-button" href="#">
-                    <img class="select-button-image" src="images/icon/sort-button.svg" alt="">
+                    <img class="select-button-image" src="images/icon/sort-button.svg" alt="От меньшего к большему">
                     <span class="visually-hidden">От меньшего к большему</span>
                   </a>
                   <a class="select-button" href="#">
-                    <img class="select-button-image" src="images/icon/sort-button.svg" alt="">
+                    <img class="select-button-image" src="images/icon/sort-button.svg" alt="От большего к меньшему">
                     <span class="visually-hidden">От большего к меньшему</span>
                   </a>
                 </div>

--- a/catalog.html
+++ b/catalog.html
@@ -26,48 +26,54 @@
             <button class="search-button" type="submit">Найти</button>
           </form>
 
-          <ul class="navigation-list">
-            <li class="navigation-item">
-              <img class="login-image" src="images/icon/login.svg" width="13" height="12" alt="Вход в личный кабинет">
+          <ul class="header-login-list">
+            <li class="header-login-item">
+              <img class="navigation-image" src="images/icon/login.svg" width="13" height="12" alt="Вход в личный кабинет">
               <a class="navigation-link" href="#">Войти</a>
             </li>
+          </ul>
+
+          <ul class="navigation-list">
             <li class="navigation-item">
-              <img class="compare-image" src="images/icon/compare.svg" width="10" height="12" alt="Сравнение товара">
+              <img class="navigation-image" src="images/icon/compare.svg" width="10" height="12" alt="Сравнение товара">
               <a class="navigation-link" href="#">Сравнить</a>
             </li>
             <li class="navigation-item">
-              <img class="card-image" src="images/icon/card.svg" width="16" height="14" alt="Корзина">
+              <img class="navigation-image" src="images/icon/card.svg" width="16" height="14" alt="Корзина">
               <a class="navigation-link" href="#">Корзина</a>
             </li>
           </ul>
         </div>
 
         <div class="navigation-catalog">
-          <h2 class="catalog">Каталог товаров</h2>
-          <img class="catalog-image" src="images/icon/catalog-button.svg" width="50" height="50" alt="Каталог">
+          <div class="catalog-menu">
+            <h2 class="catalog">Каталог товаров</h2>
+            <img class="catalog-image" src="images/icon/catalog-button.svg" width="50" height="50" alt="Каталог">
 
 <!-- Вложенный каталог
             <ul class="catalog-list">
-            <li class="catalog-item">
-              <a class="catalog-item-link" href="#">Виртуальная реальность</a>
-            </li>
-            <li class="catalog-item">
-              <a class="catalog-item-link" href="#">Моноподы для селфи</a>
-            </li>
-            <li class="catalog-item">
-              <a class="catalog-item-link" href="#">Экшн-камеры</a>
-            </li>
-            <li class="catalog-item">
-              <a class="catalog-item-link" href="#">Фитнес-браслеты</a>
-            </li>
-            <li class="catalog-item">
-              <a class="catalog-item-link" href="#">Умные часы</a>
-            </li>
-            <li class="catalog-item">
-              <a class="catalog-item-link" href="#">Квадрокоптеры</a>
-            </li>
-          </ul>
+              <li class="catalog-item">
+                <a class="catalog-item-link" href="#">Виртуальная реальность</a>
+              </li>
+              <li class="catalog-item">
+                <a class="catalog-item-link" href="#">Моноподы для селфи</a>
+              </li>
+              <li class="catalog-item">
+                <a class="catalog-item-link" href="#">Экшн-камеры</a>
+              </li>
+              <li class="catalog-item">
+                <a class="catalog-item-link" href="#">Фитнес-браслеты</a>
+              </li>
+              <li class="catalog-item">
+                <a class="catalog-item-link" href="#">Умные часы</a>
+              </li>
+              <li class="catalog-item">
+                <a class="catalog-item-link" href="#">Квадрокоптеры</a>
+              </li>
+            </ul>
 -->
+          </div>
+
           <ul class="menu-list">
             <li class="menu-item">
               <a class="menu-item-link" href="#">Доставка</a>
@@ -167,29 +173,26 @@
           </div>
 
           <div class="sorting-products-wrapper">
-
             <div class="sorting">
-              <span class="sorting-text">Сортировка</span>
-              <div class="select-control-wrapper">
+              <div class="sorting-wrapper">
+                <span class="sorting-text">Сортировка:</span>
+
                 <select class="select-control" aria-label="Сортировка товара">
                   <option value="popular">Популярные</option>
                   <option value="cheap">Сначала дешёвые</option>
                   <option value="expensive">Сначала дорогие</option>
                 </select>
-                <button>
-                  <img src="images/icon/popular-arrow.svg" alt="">
-                </button>
-              </div>
 
-              <div class="sort-button-wrapper">
-                <a class="select-button" href="#">
-                  <img src="images/icon/sort-button.svg" alt="">
-                  <span class="visually-hidden">От меньшего к большему</span>
-                </a>
-                <a class="select-button" href="#">
-                  <img src="images/icon/sort-button.svg" alt="">
-                  <span class="visually-hidden">От большего к меньшему</span>
-                </a>
+                <div class="sort-button-wrapper">
+                  <a class="select-button" href="#">
+                    <img class="select-button-image" src="images/icon/sort-button.svg" alt="">
+                    <span class="visually-hidden">От меньшего к большему</span>
+                  </a>
+                  <a class="select-button" href="#">
+                    <img class="select-button-image" src="images/icon/sort-button.svg" alt="">
+                    <span class="visually-hidden">От большего к меньшему</span>
+                  </a>
+                </div>
               </div>
             </div>
 
@@ -200,34 +203,34 @@
                   <li class="product-item">
                     <a class="product-link" href="#">
                       <img class="product-img" src="images/products/product-1.jpg" width="360" height="380" alt="">
-                      <b class="product-name">Любительская <br>
+                      <b class="product-name">Любительская
                         селфи-палка</b>
+                      <span class="product-price">500 ₽</span>
                     </a>
-                    <span class="product-price">500 ₽</span>
                   </li>
                   <li class="product-item">
                     <a class="product-link" href="#">
                       <img class="product-img" src="images/products/product-2.jpg" width="360" height="380" alt="">
-                      <b class="product-name">Профессиональная <br>
+                      <b class="product-name">Профессиональная
                         селфи-палка</b>
+                      <span class="product-price">1 500 ₽</span>
                     </a>
-                    <span class="product-price">1 500 ₽</span>
                   </li>
                   <li class="product-item">
                     <a class="product-link" href="#">
                       <img class="product-img" src="images/products/product-3.jpg" width="360" height="380" alt="">
                       <b class="product-name">Непотопляемая <br>
                         селфи-палка</b>
+                      <span class="product-price">2 500 ₽</span>
                     </a>
-                    <span class="product-price">2 500 ₽</span>
+
                   </li>
                   <li class="product-item">
                     <a class="product-link" href="#">
                       <img class="product-img" src="images/products/product-4.jpg" width="360" height="380" alt="">
-                      <b class="product-name">Селфи-палка «Следуй <br>
-                        за мной»</b>
+                      <b class="product-name">Селфи-палка «Следуй за мной»</b>
+                      <span class="product-price">1 500 ₽</span>
                     </a>
-                    <span class="product-price">1 500 ₽</span>
                   </li>
                 </ul>
 
@@ -254,7 +257,6 @@
                   </ul>
                   <a class="pagination-link-next" href="#">Вперёд</a>
                 </div>
-
               </div>
             </section>
           </div>
@@ -263,83 +265,87 @@
     </main>
 
     <footer class="main-footer">
-
       <div class="footer-wrapper">
-        <h2 class="visually-hidden">Магазин Device</h2>
-        <a class="footer-logo" href="index.html">
-          <img class="logo" src="images/logo/device-logo.svg" width="145" height="36" alt="Магазин Device">
-        </a>
+        <div class="footer-logo-address-line">
+          <h2 class="visually-hidden">Магазин Device</h2>
+          <a class="footer-logo" href="index.html">
+            <img class="logo" src="images/logo/device-logo.svg" width="145" height="36" alt="Магазин Device">
+          </a>
 
-        <section class="footer-address">
-          <h2 class="visually-hidden">Адрес</h2>
-          <address class="footer-address-address">
-            <p class="footer-address-text">Санкт-Петербург, набережная
-              реки Карповки, 5, литера П.</p>
-          </address>
-        </section>
-
-        <section class="footer-menu">
-          <ul class="footer-menu-list">
-            <li class="footer-menu-item">
-              <a class="footer-menu-link" href="">
-                <h2 class="footer-menu-title">Доставка</h2>
-              </a>
-            </li>
-            <li class="footer-menu-item">
-              <a class="footer-menu-link" href="">
-                <h2 class="footer-menu-title">Гарантия</h2>
-              </a>
-            </li>
-            <li class="footer-menu-item">
-              <a class="footer-menu-link" href="">
-                <h2 class="footer-menu-title">Контакты</h2>
-              </a>
-            </li>
-          </ul>
-        </section>
-
-        <section class="footer-phone">
-            <h2 class="visually-hidden">Телефон</h2>
-            <address class="footer-address-phone">
-              <a class="footer-phone" href="tel:+78128121212">Тел.: +7 (812) 812-12-12</a>
+          <section class="footer-address">
+            <h2 class="visually-hidden">Адрес</h2>
+            <address class="footer-address-address">
+              <p class="footer-address-text">Санкт-Петербург, набережная
+                реки Карповки, 5, литера П.</p>
             </address>
-        </section>
+          </section>
 
-        <svg class="footer-line" width="80" height="7">
+          <svg width="80" height="7">
             <rect width="80" height="7" style="fill:#FFC700"/>
-        </svg>
+          </svg>
+        </div>
 
-        <section class="footer-social">
-          <h2 class="visually-hidden">Социальные сети</h2>
+        <div class="footer-menu-social">
+          <section class="footer-menu">
+            <ul class="footer-menu-list">
+              <li class="footer-menu-item">
+                <a class="footer-menu-link" href="">
+                  <h2 class="footer-menu-title">Доставка</h2>
+                </a>
+              </li>
+              <li class="footer-menu-item">
+                <a class="footer-menu-link" href="">
+                  <h2 class="footer-menu-title">Гарантия</h2>
+                </a>
+              </li>
+              <li class="footer-menu-item">
+                <a class="footer-menu-link" href="">
+                  <h2 class="footer-menu-title">Контакты</h2>
+                </a>
+              </li>
+            </ul>
+          </section>
 
-          <ul class="footer-social-list">
-            <li class="footer-social-item">
-              <a class="social-button" href="https://t.me/htmlacademy">
-                <img class="social-image" src="images/icon/telegram.svg" width="40" height="40" alt="Телеграм">
-                <span class="visually-hidden">Telegram</span>
-              </a>
-            </li>
-            <li class="footer-social-item">
-              <a class="social-button" href="https://www.youtube.com/user/htmlacademyru">
-                <img class="social-image" src="images/icon/youtube.svg" width="40" height="40" alt="Ютуб">
-                <span class="visually-hidden">YouTube</span>
-              </a>
-            </li>
-            <li class="footer-social-item">
-              <a class="social-button" href="https://twitter.com/htmlacademy_ru">
-                <img class="social-image" src="images/icon/twitter.svg" width="40" height="40" alt="твиттер">
-                <span class="visually-hidden">Twitter</span>
-              </a>
-            </li>
-          </ul>
-        </section>
+          <section class="footer-social">
+            <h2 class="visually-hidden">Социальные сети</h2>
 
-        <a class="footer-academy-link" href="https://htmlacademy.ru/">
-          <img class="htmlacademy-link" src="images/icon/html-academy.svg" width="115" height="33" alt="Логотип разработчика htmlacademy">
-          <span class="visually-hidden">Логотип разработчика .htmlacademy</span>
-        </a>
+            <ul class="footer-social-list">
+              <li class="footer-social-item">
+                <a class="social-button" href="https://t.me/htmlacademy">
+                  <img class="social-image" src="images/icon/telegram.svg" width="40" height="40" alt="Телеграм">
+                  <span class="visually-hidden">Telegram</span>
+                </a>
+              </li>
+              <li class="footer-social-item">
+                <a class="social-button" href="https://www.youtube.com/user/htmlacademyru">
+                  <img class="social-image" src="images/icon/youtube.svg" width="40" height="40" alt="Ютуб">
+                  <span class="visually-hidden">YouTube</span>
+                </a>
+              </li>
+              <li class="footer-social-item">
+                <a class="social-button" href="https://twitter.com/htmlacademy_ru">
+                  <img class="social-image" src="images/icon/twitter.svg" width="40" height="40" alt="твиттер">
+                  <span class="visually-hidden">Twitter</span>
+                </a>
+              </li>
+            </ul>
+          </section>
+        </div>
 
+        <div class="footer-phone-academy-link">
+          <section class="footer-phone">
+              <h2 class="visually-hidden">Телефон</h2>
+              <address class="footer-address-phone">
+                <a class="footer-phone" href="tel:+78128121212">Тел.: +7 (812) 812-12-12</a>
+              </address>
+          </section>
+          <a class="footer-academy-link" href="https://htmlacademy.ru/">
+            <img class="htmlacademy-link" src="images/icon/html-academy.svg" width="115" height="33" alt="Логотип разработчика htmlacademy">
+            <span class="visually-hidden">Логотип разработчика .htmlacademy</span>
+          </a>
+        </div>
       </div>
     </footer>
+
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -25,48 +25,54 @@
             <button class="search-button" type="submit">Найти</button>
           </form>
 
-          <ul class="navigation-list">
-            <li class="navigation-item">
-              <img class="login-image" src="images/icon/login.svg" width="13" height="12" alt="Вход в личный кабинет">
+          <ul class="header-login-list">
+            <li class="header-login-item">
+              <img class="navigation-image" src="images/icon/login.svg" width="13" height="12" alt="Вход в личный кабинет">
               <a class="navigation-link" href="#">Войти</a>
             </li>
+          </ul>
+
+          <ul class="navigation-list">
             <li class="navigation-item">
-              <img class="compare-image" src="images/icon/compare.svg" width="10" height="12" alt="Сравнение товара">
+              <img class="navigation-image" src="images/icon/compare.svg" width="10" height="12" alt="Сравнение товара">
               <a class="navigation-link" href="#">Сравнить</a>
             </li>
             <li class="navigation-item">
-              <img class="card-image" src="images/icon/card.svg" width="16" height="14" alt="Корзина">
+              <img class="navigation-image" src="images/icon/card.svg" width="16" height="14" alt="Корзина">
               <a class="navigation-link" href="#">Корзина</a>
             </li>
           </ul>
         </div>
 
         <div class="navigation-catalog">
-          <h2 class="catalog">Каталог товаров</h2>
-          <img class="catalog-image" src="images/icon/catalog-button.svg" width="50" height="50" alt="Каталог">
+          <div class="catalog-menu">
+            <h2 class="catalog">Каталог товаров</h2>
+            <img class="catalog-image" src="images/icon/catalog-button.svg" width="50" height="50" alt="Каталог">
 
 <!-- Вложенный каталог
             <ul class="catalog-list">
-            <li class="catalog-item">
-              <a class="catalog-item-link" href="#">Виртуальная реальность</a>
-            </li>
-            <li class="catalog-item">
-              <a class="catalog-item-link" href="#">Моноподы для селфи</a>
-            </li>
-            <li class="catalog-item">
-              <a class="catalog-item-link" href="#">Экшн-камеры</a>
-            </li>
-            <li class="catalog-item">
-              <a class="catalog-item-link" href="#">Фитнес-браслеты</a>
-            </li>
-            <li class="catalog-item">
-              <a class="catalog-item-link" href="#">Умные часы</a>
-            </li>
-            <li class="catalog-item">
-              <a class="catalog-item-link" href="#">Квадрокоптеры</a>
-            </li>
-          </ul>
+              <li class="catalog-item">
+                <a class="catalog-item-link" href="#">Виртуальная реальность</a>
+              </li>
+              <li class="catalog-item">
+                <a class="catalog-item-link" href="#">Моноподы для селфи</a>
+              </li>
+              <li class="catalog-item">
+                <a class="catalog-item-link" href="#">Экшн-камеры</a>
+              </li>
+              <li class="catalog-item">
+                <a class="catalog-item-link" href="#">Фитнес-браслеты</a>
+              </li>
+              <li class="catalog-item">
+                <a class="catalog-item-link" href="#">Умные часы</a>
+              </li>
+              <li class="catalog-item">
+                <a class="catalog-item-link" href="#">Квадрокоптеры</a>
+              </li>
+            </ul>
 -->
+          </div>
+
           <ul class="menu-list">
             <li class="menu-item">
               <a class="menu-item-link" href="#">Доставка</a>
@@ -332,9 +338,9 @@
           <h2 class="contacts-title">Контакты</h2>
           <p class="contacts-text">Вы можете забрать товар сами, заехав в наш офис. <br>
             Заодно сможете проверить работоспособность покупки.</p>
-          <h3 class="contacts-adress">Интернет-магазин «Девайс»</h3>
 
-          <address class="contacts-address">
+          <h3 class="contacts-adress">Интернет-магазин «Девайс»</h3>
+          <address class="contacts-address-address">
             <p class="contacts-adress-text">Санкт-Петербург, набережная реки Карповки, 5, литера П.</p>
             <a class="contacts-phone" href="tel:+78128121212">+7 (812) 812-12-12</a>
           </address>
@@ -374,87 +380,89 @@
             <span class="subscribe-free">Это бесплатно</span>
           </div>
         </div>
-
       </section>
     </main>
 
     <footer class="main-footer">
-
       <div class="footer-wrapper">
-        <h2 class="visually-hidden">Магазин Device</h2>
-        <a class="footer-logo" href="index.html">
-          <img class="logo" src="images/logo/device-logo.svg" width="145" height="36" alt="Магазин Device">
-        </a>
+        <div class="footer-logo-address-line">
+          <h2 class="visually-hidden">Магазин Device</h2>
+          <a class="footer-logo" href="index.html">
+            <img class="logo" src="images/logo/device-logo.svg" width="145" height="36" alt="Магазин Device">
+          </a>
 
-        <section class="footer-address">
-          <h2 class="visually-hidden">Адрес</h2>
-          <address class="footer-address-address">
-            <p class="footer-address-text">Санкт-Петербург, набережная
-              реки Карповки, 5, литера П.</p>
-          </address>
-        </section>
+          <section class="footer-address">
+            <h2 class="visually-hidden">Адрес</h2>
+            <address class="footer-address-address">
+              <p class="footer-address-text">Санкт-Петербург, набережная
+                реки Карповки, 5, литера П.</p>
+            </address>
+          </section>
 
-        <section class="footer-menu">
-          <ul class="footer-menu-list">
-            <li class="footer-menu-item">
-              <a class="footer-menu-link" href="">
-                <h2 class="footer-menu-title">Доставка</h2>
-              </a>
-            </li>
-            <li class="footer-menu-item">
-              <a class="footer-menu-link" href="">
-                <h2 class="footer-menu-title">Гарантия</h2>
-              </a>
-            </li>
-            <li class="footer-menu-item">
-              <a class="footer-menu-link" href="">
-                <h2 class="footer-menu-title">Контакты</h2>
-              </a>
-            </li>
-          </ul>
-        </section>
+          <svg width="80" height="7">
+            <rect width="80" height="7" style="fill:#FFC700"/>
+          </svg>
+        </div>
 
-        <section class="footer-phone">
+        <div class="footer-menu-social">
+          <section class="footer-menu">
+            <ul class="footer-menu-list">
+              <li class="footer-menu-item">
+                <a class="footer-menu-link" href="">
+                  <h2 class="footer-menu-title">Доставка</h2>
+                </a>
+              </li>
+              <li class="footer-menu-item">
+                <a class="footer-menu-link" href="">
+                  <h2 class="footer-menu-title">Гарантия</h2>
+                </a>
+              </li>
+              <li class="footer-menu-item">
+                <a class="footer-menu-link" href="">
+                  <h2 class="footer-menu-title">Контакты</h2>
+                </a>
+              </li>
+            </ul>
+          </section>
+
+          <section class="footer-social">
+            <h2 class="visually-hidden">Социальные сети</h2>
+
+            <ul class="footer-social-list">
+              <li class="footer-social-item">
+                <a class="social-button" href="https://t.me/htmlacademy">
+                  <img class="social-image" src="images/icon/telegram.svg" width="40" height="40" alt="Телеграм">
+                  <span class="visually-hidden">Telegram</span>
+                </a>
+              </li>
+              <li class="footer-social-item">
+                <a class="social-button" href="https://www.youtube.com/user/htmlacademyru">
+                  <img class="social-image" src="images/icon/youtube.svg" width="40" height="40" alt="Ютуб">
+                  <span class="visually-hidden">YouTube</span>
+                </a>
+              </li>
+              <li class="footer-social-item">
+                <a class="social-button" href="https://twitter.com/htmlacademy_ru">
+                  <img class="social-image" src="images/icon/twitter.svg" width="40" height="40" alt="твиттер">
+                  <span class="visually-hidden">Twitter</span>
+                </a>
+              </li>
+            </ul>
+          </section>
+        </div>
+
+        <div class="footer-phone-academy-link">
+          <section class="footer-phone">
             <h2 class="visually-hidden">Телефон</h2>
             <address class="footer-address-phone">
               <a class="footer-phone" href="tel:+78128121212">Тел.: +7 (812) 812-12-12</a>
             </address>
-        </section>
-
-        <svg class="footer-line" width="80" height="7">
-            <rect width="80" height="7" style="fill:#FFC700"/>
-        </svg>
-
-        <section class="footer-social">
-          <h2 class="visually-hidden">Социальные сети</h2>
-
-          <ul class="footer-social-list">
-            <li class="footer-social-item">
-              <a class="social-button" href="https://t.me/htmlacademy">
-                <img class="social-image" src="images/icon/telegram.svg" width="40" height="40" alt="Телеграм">
-                <span class="visually-hidden">Telegram</span>
-              </a>
-            </li>
-            <li class="footer-social-item">
-              <a class="social-button" href="https://www.youtube.com/user/htmlacademyru">
-                <img class="social-image" src="images/icon/youtube.svg" width="40" height="40" alt="Ютуб">
-                <span class="visually-hidden">YouTube</span>
-              </a>
-            </li>
-            <li class="footer-social-item">
-              <a class="social-button" href="https://twitter.com/htmlacademy_ru">
-                <img class="social-image" src="images/icon/twitter.svg" width="40" height="40" alt="твиттер">
-                <span class="visually-hidden">Twitter</span>
-              </a>
-            </li>
-          </ul>
-        </section>
-
-        <a class="footer-academy-link" href="https://htmlacademy.ru/">
-          <img class="htmlacademy-link" src="images/icon/html-academy.svg" width="115" height="33" alt="Логотип разработчика htmlacademy">
-          <span class="visually-hidden">Логотип разработчика .htmlacademy</span>
-        </a>
-
+          </section>
+          <a class="footer-academy-link" href="https://htmlacademy.ru/">
+            <img class="htmlacademy-link" src="images/icon/html-academy.svg" width="115" height="33" alt="Логотип разработчика htmlacademy">
+            <span class="visually-hidden">Логотип разработчика .htmlacademy</span>
+          </a>
+        </div>
       </div>
     </footer>
   </body>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -958,7 +958,7 @@ body {
 
   display: grid;
   grid-template-columns: 226px 77px;
-  grid-template-rows: 380px 40px;
+  grid-template-rows: 380px auto;
   gap: 32px 57px;
 
   grid-template-areas: "img img"
@@ -974,7 +974,7 @@ body {
   font-weight: 700;
   font-size: 18px;
   letter-spacing: -0.02em;
-  
+
 
   display: block;
   color: #000000;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -43,7 +43,14 @@ body {
 }
 
 .visually-hidden {
-  display: none;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  overflow: hidden;
 }
 
 /*index.html*/
@@ -72,10 +79,27 @@ body {
   font-size: 16px;
 }
 
+.header-login-list {
+  width: 231px;
+  margin: 0;
+  margin-left: 26px;
+  padding: 0;
+}
+
+.header-login-item {
+  display: inline;
+  list-style: none;
+}
+
+.navigation-image {
+  margin-right: 12px;
+}
+
 .navigation-list {
   margin: 0;
-  padding: 0;
   margin-left: auto;
+  padding: 0;
+
 }
 
 .navigation-item {
@@ -87,9 +111,18 @@ body {
   color: #000000;
 }
 
+.navigation-item:not(:last-child) {
+  margin-right: 36px;
+}
+
 .navigation-catalog {
   width: 1040px;
   margin: 0 auto;
+  display: flex;
+  align-items: center;
+}
+
+.catalog-menu {
   display: flex;
   align-items: center;
 }
@@ -102,8 +135,7 @@ body {
   letter-spacing: 0.2em;
   text-transform: uppercase;
   color: #000000;
-  margin: 0;
-
+  margin: 0 7px 0 0;
 }
 
 .catalog-item-link {
@@ -113,22 +145,23 @@ body {
   color: #000000;
 }
 
-.catalog-image {
-  position: absolute;
-  margin-left: 243px;
-}
-
 .menu-list {
   margin: 0;
-  padding: 0;
   margin-left: auto;
+  padding: 0;
 }
 
 .menu-item {
   display: inline;
 }
 
+.menu-item:not(:last-child) {
+  margin-right: 45px;
+}
+
 .menu-item-link {
+  margin: 0;
+  padding: 0;
   font-family: "Raleway", sans-serif;
   font-weight: 800;
   font-size: 18px;
@@ -147,6 +180,10 @@ body {
   flex-grow: 1;
 }
 
+.product-slider {
+  margin-bottom: 70px;
+}
+
 .product-one,
 .product-two,
 .product-three {
@@ -158,7 +195,7 @@ body {
 
 .product-wrapper {
   width: 560px;
-}
+  }
 
 .product-button {
   background-color: inherit;
@@ -180,13 +217,12 @@ body {
 
 .description-wrapper {
   width: 560px;
-  margin-left: auto;
 }
 
 .product-number {
   display: inline-block;
-  margin-top: 100px;
-  margin-bottom: 100px;
+  padding-top: 100px;
+  padding-bottom: 100px;
 
   font-weight: 700;
   font-size: 180px;
@@ -196,6 +232,7 @@ body {
 
 .product-title {
   margin: 0;
+  margin-bottom: 29px;
   font-family: "Raleway", sans-serif;
   font-weight: 800;
   font-size: 50px;
@@ -205,6 +242,7 @@ body {
 
 .product-description {
   margin: 0;
+  margin-bottom: 50px;
 }
 
 .button {
@@ -223,12 +261,23 @@ body {
 .properties-button {
   width: 220px;
   height: 40px;
+  margin-bottom: 50px;
 }
 
 .properties-list {
   margin: 0;
   padding: 0;
   list-style: none;
+
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+.properties-item {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .properties {
@@ -238,22 +287,31 @@ body {
 }
 
 .properties-description {
+  max-width: 280px;
+  display: flex;
+  flex-wrap: wrap;
   font-size: 16px;
 }
 
 /*category*/
+
+.category {
+  margin-bottom: 70px;
+}
 
 .category-list {
   width: 1160px;
   margin: 0 auto;
   padding: 0;
   display: flex;
+  flex-wrap: wrap;
   gap: 40px;
 }
 
 .category-item {
   width: 160px;
   list-style: none;
+
 }
 
 .category-item-wrapper {
@@ -286,6 +344,7 @@ body {
 .services-slider {
   width: 1160px;
   margin: 0 auto;
+  margin-bottom: 70px;
   display: flex;
   background-color: #F0F0F0;
 }
@@ -354,11 +413,12 @@ body {
 /*delivery*/
 
 .delivery {
-  display: flex;
-  justify-content: space-between;
   width: 1160px;
   height: 100px;
-  margin: 70px auto;
+  margin: 0 auto;
+  margin-bottom: 70px;
+  display: flex;
+  justify-content: space-between;
   align-items: center;
   background-color: #F0F0F0;
 }
@@ -393,13 +453,16 @@ body {
 
 .about-us-contacts-wrapper {
   width: 1160px;
+  margin: 0 auto;
+  margin-bottom: 70px;
   display: flex;
   justify-content: space-between;
-  margin: 0 auto;
 }
 
 .about-us {
   width: 520px;
+  display: flex;
+  flex-direction: column;
 }
 
 .about-us-title {
@@ -408,6 +471,19 @@ body {
   font-size: 50px;
   line-height: 50px;
   color: #000000;
+
+  margin: 40px auto 48px 0;
+}
+
+.about-us-text {
+  margin: 0;
+  margin-bottom: 30px;
+}
+
+.delivery-company-list {
+  margin: 0;
+  margin-bottom: 30px;
+  padding: 0;
 }
 
 .delivery-company-item {
@@ -417,8 +493,13 @@ body {
   color: #000000;
 }
 
+.delivery-company-item:not(:last-child) {
+  margin-bottom: 19px;
+}
+
 .delivery-company-item::marker {
   color: #FFC700;
+  margin-left: 30px;
 }
 
 .about-us-button {
@@ -430,6 +511,9 @@ body {
 
 .contacts {
   width: 532px;
+
+  display: flex;
+  flex-direction: column;
 }
 
 .contacts-title {
@@ -438,15 +522,28 @@ body {
   font-size: 50px;
   line-height: 50px;
   color: #000000;
+  margin: 40px auto 48px 0;
+}
+
+.contacts-text {
+  margin: 0;
+  margin-bottom: 30px;
 }
 
 .contacts-adress {
   font-weight: 700;
   font-size: 24px;
-  }
+  margin: 0;
+  margin-bottom: 15px;
+}
+
+.contacts-address-address {
+  margin-bottom: 30px;
+}
 
 .contacts-adress-text {
   font-style: normal;
+  margin: 0;
 }
 
 .contacts-phone {
@@ -457,9 +554,13 @@ body {
 .contacts-schedule {
   font-weight: 700;
   font-size: 24px;
+  margin: 0;
+  margin-bottom: 15px;
 }
 
 .contacts-schedule-list {
+  margin: 0;
+  margin-bottom: 30px;
   padding: 0;
 }
 
@@ -483,8 +584,7 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 144px;
-  padding: 64px 133px 0 147px;
+  padding: 64px 133px 144px 147px;
 }
 
 .subscribe-title {
@@ -549,23 +649,20 @@ body {
   width: 1160px;
   margin: 0 auto;
 
-  display: grid;
-  grid-template-columns: 239px 1fr 175px;
-  grid-template-areas: "logo . ."
-                       "adress footer-menu phone"
-                       "line social academy";
-  justify-items: center;
+  display: flex;
+}
+
+.footer-logo-address-line {
+  width: 239px;
+  margin: 62px 119px 0 0;
+
+  display: flex;
+  flex-direction: column;
 }
 
 .footer-logo {
   display: block;
-  grid-area: logo;
-  justify-self: start;
-}
-
-.footer-address {
-  width: 239px;
-  grid-area: adress;
+  margin-bottom: 35px;
 }
 
 .footer-address-text {
@@ -573,23 +670,31 @@ body {
   font-size: 16px;
   line-height: 20px;
   margin: 0;
+  margin-bottom: 64px;
+}
+
+.footer-menu-social {
+  width: 444px;
+  margin: 137px auto 61px 0;
+
+  display: flex;
+  flex-direction: column;
 }
 
 .footer-menu {
-  grid-area: footer-menu;
+  margin-bottom: 62px;
 }
 
 .footer-menu-list {
   margin: 0;
   padding: 0;
+
+  display: flex;
+  justify-content: space-between;
 }
 
 .footer-menu-item {
   display: inline;
-}
-
-.footer-menu-item:not(:last-child) {
-  margin-right: 35px;
 }
 
 .footer-menu-link {
@@ -606,28 +711,14 @@ body {
   color: #FFFFFF;
 }
 
-.footer-phone {
-  font-style: normal;
-  font-size: 16px;
-  line-height: 20px;
-  width: 175px;
-  color: #FFFFFF;
-
-  grid-area: phone;
-}
-
-.footer-line {
-  grid-area: line;
-  justify-self: start;
-}
-
-.footer-social {
-  grid-area: social;
-}
-
 .footer-social-list {
   padding: 0;
   margin: 0;
+
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px;
+  justify-content: center;
 }
 
 .footer-social-item {
@@ -635,18 +726,61 @@ body {
   display: inline;
 }
 
-.footer-social-item:not(:last-child) {
-  margin-right: 15px;
-}
-
 .social-button {
   text-decoration: none;
 }
 
-.footer-academy-link {
-  grid-area: academy;
-  justify-self: end;
+.footer-phone-academy-link {
+  display: flex;
+  flex-direction: column;
+  width: 175px;
+  margin: 140px 0 65px 0;
 }
+
+.footer-phone {
+  font-style: normal;
+  font-size: 16px;
+  line-height: 20px;
+  width: 175px;
+  color: #FFFFFF;
+
+  margin-bottom: 63px;
+}
+
+.footer-academy-link {
+  margin-top: auto;
+  margin-left: auto;
+
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 /*catalog.html*/
 
@@ -664,6 +798,7 @@ body {
   display: flex;
   flex-direction: column;
   margin-top: 55px;
+  margin-bottom: 34px;
 }
 
 .inner-header-title {
@@ -715,12 +850,20 @@ body {
 
 .product-filter {
   width: 320px;
-
+  display: flex;
+  flex-direction: column;
+  align-content: center;
 }
 
 .catalog-filter {
   background-color: #F0F0F0;
 }
+
+.catalog-filter-group {
+
+  border: 0 none;
+}
+
 .filter-title {
   font-family: "Raleway", sans-serif;
   font-weight: 800;
@@ -747,11 +890,22 @@ body {
 
 /*sorting*/
 .sorting {
+  width: 840px;
   height: 70px;
+
   display: flex;
-  justify-content: space-around;
   align-items: center;
+
   background-color: #F0F0F0;
+}
+
+.sorting-wrapper {
+  width: 760px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  margin: 0 40px;
 }
 
 .sorting-text {
@@ -785,30 +939,60 @@ body {
   margin: 70px 40px auto;
 }
 
+
+
+
+
+
+
 .product-list {
   padding: 0;
   margin: 0;
+  margin-bottom: 44px;
+
+  display: grid;
+  grid-template-columns: 360px 360px;
+  gap: 44px 40px;
 }
 
 .product-item {
   list-style: none;
 }
 
+
 .product-link {
-  font-weight: 700;
-  font-size: 18px;
-  letter-spacing: -0.02em;
   text-decoration: none;
-  color: #000000;
+
+  display: grid;
+  grid-template-columns: 226px 77px;
+  grid-template-rows: 380px 40px;
+  gap: 32px 57px;
+
+  grid-template-areas: "img img"
+                       "descr price";
 }
 
 .product-img {
   display: block;
+  grid-area: img;
+}
+
+.product-name {
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: -0.02em;
+
+  display: block;
+  color: #000000;
+
+  grid-area: descr;
 }
 
 .product-price {
   font-size: 18px;
   line-height: 21px;
+  text-align: end;
+  grid-area: price;
 }
 
 .load-more {
@@ -817,6 +1001,8 @@ body {
   font-size: 16px;
   line-height: 19px;
   border: 3px solid #E5E5E5;
+
+  margin-bottom: 44px;
 }
 
 /*pagination-list*/
@@ -824,7 +1010,6 @@ body {
 .pagination-wrapper {
   width: 760px;
   height: 71px;
-  margin-top: 44px;
   margin-bottom: 78px;
 
   display: flex;
@@ -845,29 +1030,33 @@ body {
   text-decoration: none;
 }
 
-.pagination-list {
-  width: 200px;
-  padding: 0;
-  margin: 0;
-
-  display: flex;
-  justify-content: space-between;
- }
-
- .pagination-item {
-  display: inline;
- }
-
 .pagination-link-previous {
+  box-sizing: border-box;
+  width: 128px;
+  text-align: center;
   color: #444444;
   opacity: 0.3;
 }
 
-.pagination-link-next {
-  color: #000000;
+.pagination-list {
+  display: flex;
+
+  padding: 0;
+  margin: 0;
+}
+
+ .pagination-item {
+  display: inline;
 }
 
 .pagination-link {
+  display: block;
+  box-sizing: border-box;
+  width: 40px;
+  height: 40px;
+  text-align: center;
+  padding: 10px;
+
   text-decoration: none;
   color: #444444;
   opacity: 0.3;
@@ -876,4 +1065,11 @@ body {
 .pagination-link-active {
   color: #444444;
   opacity: 0.6;
+}
+
+.pagination-link-next {
+  box-sizing: border-box;
+  width: 141px;
+  text-align: center;
+  color: #000000;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -939,12 +939,6 @@ body {
   margin: 70px 40px auto;
 }
 
-
-
-
-
-
-
 .product-list {
   padding: 0;
   margin: 0;
@@ -958,7 +952,6 @@ body {
 .product-item {
   list-style: none;
 }
-
 
 .product-link {
   text-decoration: none;
@@ -981,6 +974,7 @@ body {
   font-weight: 700;
   font-size: 18px;
   letter-spacing: -0.02em;
+  
 
   display: block;
   color: #000000;
@@ -993,6 +987,7 @@ body {
   line-height: 21px;
   text-align: end;
   grid-area: price;
+  color: #000000;
 }
 
 .load-more {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -155,9 +155,11 @@ body {
   display: inline;
 }
 
+/*
 .menu-item:not(:last-child) {
   margin-right: 45px;
 }
+*/
 
 .menu-item-link {
   margin: 0;
@@ -170,6 +172,10 @@ body {
   text-transform: uppercase;
   color: #000000;
   text-decoration: none;
+}
+
+.menu-item:not(:last-child) .menu-item-link {
+  margin-right: 45px;
 }
 
 /*product-slider*/
@@ -482,6 +488,7 @@ body {
 
 .delivery-company-list {
   margin: 0;
+  margin-left: 17px;
   margin-bottom: 30px;
   padding: 0;
 }


### PR DESCRIPTION
Добавил флексы и гриды на всех страницах. 

Появились вопросы по первой странице:
1. В хедере кнопки (войти, сравнить и корзина) на вид выглядят совсем не как на макете после выставления отступов. Хотя беру вроде все ровно. В чем проблема? 
2. В этом же блоке ниже: доставка, гарантия и контакты. Это ссылки `a`, которые находятся в `li`. При наведении, в браузере, через просмотр кода, отображается что у `li` шире чем `а`, поэтому, при выставлении отступов по макету, у меня не совпадают расстояния между элементами списка (там отступы идет между словами, выходит что между `a`). Как это починить? 
3. Как задать отступ цифре от хедера? К примеру: там стоит "01", у меня он задан тегом `span`. Он у меня накладывается на хедер. Спан - строчный элемент и не имеет верхнего и нижнего отступа, соответственно задаю `display: inline-block`. Дальше мне нужно вручную задать какой-то `margin-top`? Просто когда я смотрю через инспект в браузере: у меня цифра 01 большая (как по макету), а бокс у нее мелкий. Потратил кучу времени, решения не нашел. Может как-то можно задать так, чтобы бокс спана был автоматический и подгонялся под его высоту? 
4. В разделе "о нас" есть список компаний доставки, как маркеры списка выровнять по границе бокса? Только вручную через `padding-right`?

По второй странице: 
1. У нас есть список товаров. Я его сделал через гриды. Сетка 2х2. По логике, название товара может быть длинное и, соответственно, мы не можем задать жесткий размер для строки с названием, поэтому я задал написал `grid-template-rows: 380px auto;` (1 строка - 380px - картинка, вторая строка может тянуться). Но с другой стороны, название товара может быть очень длинным (мало ли что там напишут). В реальной верстке такое решение имеет право на существование или лучше реализовать эту логику иначе? 

---
:mortar_board: [Микросетки на флексах для всех страниц](https://up.htmlacademy.ru/htmlcss/36/user/2257983/tasks/12)